### PR TITLE
Add walkthrough steps for existing accounts in claim + merge the latest main

### DIFF
--- a/src/components/account/AccountSelector.js
+++ b/src/components/account/AccountSelector.js
@@ -122,6 +122,7 @@ export default function AccounSelector({
           {accounts.map((account, idx) => {
             return (
               <Dropdown.Item
+                key={account.address || idx}
                 eventKey={idx}
                 active={account.address === selectedAccount?.address}
                 account={account}

--- a/src/pages/gift/claim/ClaimMain.js
+++ b/src/pages/gift/claim/ClaimMain.js
@@ -9,9 +9,9 @@ import Landing from './Landing';
 import Footer from '../Footer';
 import Header from '../Header';
 import { Container, Row, Col, Card } from 'react-bootstrap';
-import CreateNewAccount from './new-account/CreateNewAccount';
+import NewAccountMain from './new-account/NewAccountMain';
 import ConnectExistingAccount from './existing-account/ConnectExistingAccount';
-import EnterExistingAccount from './existing-account/EnterExistingAccount';
+import ExistingAccountMain from './existing-account/ExistingAccountMain';
 import ConnectExtension from '../accounts/ConnectExtension';
 import ConnectSigner from '../accounts/ConnectSigner';
 
@@ -109,7 +109,7 @@ export default function ClaimMain() {
 
   const setAccountSourceHandler = (accountSource) => {
     setAccountSource(accountSource);
-    jumpToStep(2);
+    nextStep();
   };
 
   const setAddressHandler = (account) => {
@@ -124,10 +124,8 @@ export default function ClaimMain() {
   };
 
   const accountOption = {
-    NEW: CreateNewAccount,
-    EXISTING: EnterExistingAccount,
-    EXTENSION: ConnectExtension,
-    SIGNER: ConnectSigner,
+    NEW: NewAccountMain,
+    EXISTING: ExistingAccountMain,
   };
 
   if (step < 1 && address) {
@@ -135,7 +133,7 @@ export default function ClaimMain() {
   }
   const steps = [];
   // Step-0
-  steps.push(<Landing />);
+  steps.push(<Landing setAccountSourceHandler={setAccountSourceHandler} />);
 
   // Step-1
   const AccountOptionElement = accountOption[accountSource] ? (
@@ -164,7 +162,6 @@ export default function ClaimMain() {
         nextStep,
         prevStep,
         jumpToStep,
-        setAccountSourceHandler,
       }}>
       <Header selectedAccount={address} />
       <Container>

--- a/src/pages/gift/claim/ClaimMain.js
+++ b/src/pages/gift/claim/ClaimMain.js
@@ -63,7 +63,7 @@ export default function ClaimMain() {
         api?.events?.gift?.GiftClaimed?.is(event)
       );
       const {
-        event: { data }
+        event: { data },
       } = giftClaimedEvent[0];
       let claimedAmount = data && data[1].toString();
       claimedAmount = utils.fromChainUnit(claimedAmount, chainInfo.decimals);
@@ -97,7 +97,7 @@ export default function ClaimMain() {
 
       // claim gift by the selected account
       const claim = {
-        by: address
+        by: address,
       };
 
       claimGift(api, signingAccount, claim, claimGiftCallback);
@@ -127,7 +127,7 @@ export default function ClaimMain() {
     NEW: CreateNewAccount,
     EXISTING: EnterExistingAccount,
     EXTENSION: ConnectExtension,
-    SIGNER: ConnectSigner
+    SIGNER: ConnectSigner,
   };
 
   if (step < 1 && address) {
@@ -137,23 +137,23 @@ export default function ClaimMain() {
   // Step-0
   steps.push(<Landing />);
 
-  // Step-1 (skipped, if new account)
-  steps.push(<ConnectExistingAccount />);
-
-  // Step-2
-  steps.push(
+  // Step-1
+  const AccountOptionElement = accountOption[accountSource] ? (
     createElement(accountOption[accountSource], {
       setAddressHandler: setAddressHandler,
       prevStepHandler: () => {
         prevStep();
-      }
+      },
     })
+  ) : (
+    <div>No account type is selected</div>
   );
+  steps.push(AccountOptionElement);
 
-  // Step-3
+  // Step-2
   steps.push(<VerifySecret claimGiftHandler={claimGiftHandler} />);
 
-  // Step-4
+  // Step-3
   steps.push(<Claimed accountAddress={address} amount={claimedAmount} />);
 
   const currentStepComponent = steps[step];
@@ -164,7 +164,7 @@ export default function ClaimMain() {
         nextStep,
         prevStep,
         jumpToStep,
-        setAccountSourceHandler
+        setAccountSourceHandler,
       }}>
       <Header selectedAccount={address} />
       <Container>

--- a/src/pages/gift/claim/Landing.js
+++ b/src/pages/gift/claim/Landing.js
@@ -1,11 +1,9 @@
-// import Button from '../../../components/CustomButton';
 import { useContext } from 'react';
 import { ClaimContext } from './ClaimMain';
 import { Card, Row, Col } from 'react-bootstrap';
 import Button from '../../../components/CustomButton';
 import CardHeader from '../../../components/CardHeader';
-export default function Landing () {
-  const { nextStep, setAccountSourceHandler } = useContext(ClaimContext);
+export default function Landing({ setAccountSourceHandler }) {
   return (
     <>
       <Card.Body>
@@ -24,24 +22,25 @@ export default function Landing () {
             </Button>
           </Col>
         </Row>
-        <div className='d-flex flex-row align-items-center py-5'>
-            <div className='d-flex flex-grow-1 border-top'></div>
-            <div className='px-3'>Or</div>
-            <div className='d-flex flex-grow-1 border-top'></div>
+        <div className="d-flex flex-row align-items-center py-5">
+          <div className="d-flex flex-grow-1 border-top"></div>
+          <div className="px-3">Or</div>
+          <div className="d-flex flex-grow-1 border-top"></div>
         </div>
         <Row className="align-items-center">
           <div className="w-100" />
           <Col className="d-flex flex-column justify-content-center align-items-center">
             <Button
               variant="link"
-              onClick={() => nextStep()}>
+              onClick={() => setAccountSourceHandler('EXISTING')}>
               Connect Existing Account
             </Button>
           </Col>
         </Row>
       </Card.Body>
       <Card.Footer>
-        <span>By connecting an account, I accept the
+        <span>
+          By connecting an account, I accept the
           <a href="policy" target="_blank">
             &nbsp;terms and conditions
           </a>

--- a/src/pages/gift/claim/existing-account/ConnectExistingAccount.js
+++ b/src/pages/gift/claim/existing-account/ConnectExistingAccount.js
@@ -5,50 +5,49 @@ import Button from '../../../../components/CustomButton';
 import CardButton from '../../../../components/CardButton';
 import CardHeader from '../../../../components/CardHeader';
 
-const ConnectExistingAccount = () => {
-  const { setAccountSourceHandler } = useContext(ClaimContext);
-
+const ConnectExistingAccount = ({
+  setExistingAccountSourceHandler,
+  prevStepHandler,
+}) => {
   return (
-      <Card.Body>
-          <CardHeader title="Connect Account" />
-          <Col className="justify-content-center align-items-center">
-            <Col className="d-flex flex-column justify-content-center align-items-center pt-4">
-                <p className="text-center">
-                <span className="d-block">
-                    Connect an existing Polkadot account.
-                </span>
-                </p>
-                <Button
-                variant="outline-primary"
-                onClick={() => setAccountSourceHandler('EXISTING')}>
-                Enter Address Manually
-                </Button>
-            </Col>
-            <div className='d-flex flex-row align-items-center py-5'>
-                <div className='d-flex flex-grow-1 border-top'></div>
-                <div className='px-2'>Or connect with</div>
-                <div className='d-flex flex-grow-1 border-top'></div>
-            </div>
-            <Row>
-                <Col>
-                    <CardButton
-                    logo='extension'
-                    onClick={() => setAccountSourceHandler('EXTENSION')}
-                    >
-                        Polkadot Extension
-                    </CardButton>
-                </Col>
-                <Col>
-                    <CardButton
-                    logo='signer'
-                    onClick={() => setAccountSourceHandler('SIGNER')}
-                    >
-                        Parity Signer
-                    </CardButton>
-                </Col>
-            </Row>
+    <Card.Body>
+      <CardHeader title="Connect Account" backClickHandler={prevStepHandler} />
+      <Col className="justify-content-center align-items-center">
+        <Col className="d-flex flex-column justify-content-center align-items-center pt-4">
+          <p className="text-center">
+            <span className="d-block">
+              Connect an existing Polkadot account.
+            </span>
+          </p>
+          <Button
+            variant="outline-primary"
+            onClick={() => setExistingAccountSourceHandler('ENTER')}>
+            Enter Address Manually
+          </Button>
+        </Col>
+        <div className="d-flex flex-row align-items-center py-5">
+          <div className="d-flex flex-grow-1 border-top"></div>
+          <div className="px-2">Or connect with</div>
+          <div className="d-flex flex-grow-1 border-top"></div>
+        </div>
+        <Row>
+          <Col>
+            <CardButton
+              logo="extension"
+              onClick={() => setExistingAccountSourceHandler('EXTENSION')}>
+              Polkadot Extension
+            </CardButton>
           </Col>
-      </Card.Body>
+          <Col>
+            <CardButton
+              logo="signer"
+              onClick={() => setExistingAccountSourceHandler('SIGNER')}>
+              Parity Signer
+            </CardButton>
+          </Col>
+        </Row>
+      </Col>
+    </Card.Body>
   );
 };
 

--- a/src/pages/gift/claim/existing-account/EnterAccountAddress.js
+++ b/src/pages/gift/claim/existing-account/EnterAccountAddress.js
@@ -4,7 +4,7 @@ import Button from '../../../../components/CustomButton';
 import CardHeader from '../../../../components/CardHeader';
 import { useSubstrate, utils } from '../../../../substrate-lib';
 
-export default function LoadExistingAccount({
+export default function EnterAccountAddress({
   setAddressHandler,
   prevStepHandler,
 }) {

--- a/src/pages/gift/claim/existing-account/EnterExistingAccount.js
+++ b/src/pages/gift/claim/existing-account/EnterExistingAccount.js
@@ -50,7 +50,7 @@ export default function LoadExistingAccount({
                   <Form.Control
                     type="input"
                     placeholder="12YS..."
-                    isInValid={addressError}
+                    isInvalid={!!addressError}
                     onChange={(e) => {
                       setAddressError('');
                       setAddress(e.target.value);

--- a/src/pages/gift/claim/existing-account/ExistingAccountMain.js
+++ b/src/pages/gift/claim/existing-account/ExistingAccountMain.js
@@ -1,0 +1,70 @@
+import { useState, createElement } from 'react';
+import ConnectExistingAccount from './ConnectExistingAccount';
+import EnterAccountAddress from './EnterAccountAddress';
+import ConnectExtension from '../../accounts/ConnectExtension';
+import ConnectSigner from '../../accounts/ConnectSigner';
+
+export default function ExistingAccountMain({
+  setAddressHandler,
+  prevStepHandler,
+}) {
+  const [step, setStep] = useState(0);
+
+  const [processing, setProcessing] = useState(false);
+  const [processingError, setProcessingError] = useState(null);
+  const [processingMsg, setProcessingMsg] = useState('');
+  const [existingAccountSource, setExistingAccountSource] = useState(null);
+
+  const resetPresentation = () => {
+    setProcessing(false);
+    setProcessingError(null);
+  };
+  const _setStep = (step) => {
+    resetPresentation();
+    setStep(step % steps.length);
+  };
+  const nextStep = () => {
+    _setStep(step + 1);
+  };
+  const prevStep = () => {
+    _setStep(step - 1);
+  };
+  const jumpToStep = (step) => {
+    _setStep(step);
+  };
+
+  const setExistingAccountSourceHandler = (accountSource) => {
+    setExistingAccountSource(accountSource);
+    nextStep();
+  };
+
+  const accountOption = {
+    ENTER: EnterAccountAddress,
+    EXTENSION: ConnectExtension,
+    SIGNER: ConnectSigner,
+  };
+
+  const steps = [];
+  // add Step-0
+  steps.push(
+    <ConnectExistingAccount
+      setExistingAccountSourceHandler={setExistingAccountSourceHandler}
+      prevStepHandler={prevStepHandler}
+    />
+  );
+
+  // add Step-1
+  const AccountOptionElement = accountOption[existingAccountSource] ? (
+    createElement(accountOption[existingAccountSource], {
+      setAddressHandler: setAddressHandler,
+      prevStepHandler: () => {
+        prevStep();
+      },
+    })
+  ) : (
+    <div>No account type is selected</div>
+  );
+  steps.push(AccountOptionElement);
+
+  return <>{steps[step]}</>;
+}

--- a/src/pages/gift/claim/new-account/NewAccountMain.js
+++ b/src/pages/gift/claim/new-account/NewAccountMain.js
@@ -4,10 +4,7 @@ import { mnemonicGenerate } from '@polkadot/util-crypto';
 import PresentAccountPhrase from './PresentAccountPhrase';
 import VerifyAccountPhrase from './VerifyAccountPhrase';
 
-export default function CreateNewAccount({
-  setAddressHandler,
-  prevStepHandler,
-}) {
+export default function NewAccountMain({ setAddressHandler, prevStepHandler }) {
   const { keyring } = useSubstrate();
   const [step, setStep] = useState(0);
 

--- a/src/pages/gift/claim/new-account/PresentAccountPhrase.js
+++ b/src/pages/gift/claim/new-account/PresentAccountPhrase.js
@@ -33,7 +33,7 @@ export default function CreateNewAccount({
           </Row>
           <Row className="p-5 justify-content-center align-items-center">
             {mnemonicWords.map((word, index) => (
-              <Col md={4}>
+              <Col md={4} key={index}>
                 <div className=" d-flex flex-row border-bottom border-primary">
                   <div className="text-secondary"> {`${index + 1}.`}</div>
                   <div className="text-center m-auto">{`${word}`}</div>
@@ -47,7 +47,7 @@ export default function CreateNewAccount({
                 type="checkbox"
                 value={checked}
                 label={label}
-                isInValid={checkedError}
+                isInvalid={!!checkedError}
                 onChange={(e) => {
                   setCheckedError('');
                   setChecked(e.target.checked);

--- a/src/pages/gift/claim/new-account/PresentAccountPhrase.js
+++ b/src/pages/gift/claim/new-account/PresentAccountPhrase.js
@@ -3,7 +3,7 @@ import { Row, Col, Form, Card } from 'react-bootstrap';
 import CardHeader from '../../../../components/CardHeader';
 import Button from '../../../../components/CustomButton';
 
-export default function CreateNewAccount({
+export default function PresentAccountPhrase({
   mnemonicWords,
   nextStepHandler,
   prevStepHandler,

--- a/src/pages/gift/generate/GenerateGift.js
+++ b/src/pages/gift/generate/GenerateGift.js
@@ -106,7 +106,7 @@ export default function GenerateGift({ account, generateGiftHandler }) {
                     type="email"
                     placeholder=""
                     value={formValues?.email}
-                    isInvalid={formErrors?.email}
+                    isInvalid={!!formErrors?.email}
                     onChange={(e) => {
                       setFormErrors({ ...formErrors, email: '' });
                       setFormValues({ ...formValues, email: e.target.value });
@@ -119,7 +119,7 @@ export default function GenerateGift({ account, generateGiftHandler }) {
                     type="email"
                     placeholder=""
                     value={formValues?.confirmEmail}
-                    isInvalid={formErrors?.confirmEmail}
+                    isInvalid={!!formErrors?.confirmEmail}
                     onChange={(e) => {
                       setFormErrors({ ...formErrors, confirmEmail: '' });
                       setFormValues({
@@ -155,7 +155,9 @@ export default function GenerateGift({ account, generateGiftHandler }) {
                   />
                   <InputGroup.Append>
                     <InputGroup.Text
-                      style={{ ...(formErrors?.amount && borderColor: 'red') }}
+                      style={{
+                        ...(formErrors?.amount ? { borderColor: 'red' } : {}),
+                      }}
                       className="bg-transparent border-left-0 balance-text">
                       {balance?.free
                         ? `${utils.fromChainUnit(

--- a/src/pages/gift/generate/GenerateMain.js
+++ b/src/pages/gift/generate/GenerateMain.js
@@ -33,14 +33,12 @@ export default function GenerateMain() {
   const [processingMsg, setProcessingMsg] = useState('');
   const [gift, setGift] = useState(null);
 
-  const [
-    { isQrHashed, qrAddress, qrPayload, qrResolve },
-    setQrState,
-  ] = useState({
-    isQrHashed: false,
-    qrAddress: '',
-    qrPayload: new Uint8Array(),
-  });
+  const [{ isQrHashed, qrAddress, qrPayload, qrResolve }, setQrState] =
+    useState({
+      isQrHashed: false,
+      qrAddress: '',
+      qrPayload: new Uint8Array(),
+    });
 
   const resetPresentation = () => {
     setProcessing(false);
@@ -232,12 +230,15 @@ export default function GenerateMain() {
   steps.push(<ConnectAccount />);
 
   // Step-2
-  steps.push(
+  const AccountOptionElement = accountOption[accountSource] ? (
     createElement(accountOption[accountSource], {
       setAccountHandler,
       prevStepHandler: prevStep,
     })
+  ) : (
+    <div>No account type is selected</div>
   );
+  steps.push(AccountOptionElement);
 
   // Step-3
   steps.push(

--- a/src/polkadot.scss
+++ b/src/polkadot.scss
@@ -1,7 +1,7 @@
 // Custom.scss
-@import '~bootstrap/scss/_functions.scss';
+/* @import '~bootstrap/scss/_functions.scss';
 @import '~bootstrap/scss/_variables.scss';
-@import '~bootstrap/scss/mixins/_breakpoints.scss';
+@import '~bootstrap/scss/mixins/_breakpoints.scss'; */
 
 // set font family
 $font-family-base: 'Work Sans', sans-serif;
@@ -89,7 +89,7 @@ $input--color: $gray-900;
 $input-height: 2.5rem;
 
 // Footer
-@include media-breakpoint-between(xs, sm) {
+/* @include media-breakpoint-between(xs, sm) {
   footer {
     flex-direction: column !important;
     gap: 12px;
@@ -104,7 +104,7 @@ $input-height: 2.5rem;
   footer {
     flex-direction: row !important;
   }
-}
+} */
 
 // headings
 $headings-font-weight: bold;


### PR DESCRIPTION
This should fix the steps for the existing account page by  adding them as a nested walkthrough.
I also merged the most recent main branch to avoid future conflicts. 
The merges from main should fix the warning about undefined element and a couple more warnings that we were getting from react.