### PR TITLE
Alternative Seed Phrase styling

### DIFF
--- a/src/components/CardHeader.js
+++ b/src/components/CardHeader.js
@@ -1,12 +1,24 @@
-import { Row, Col, Image } from 'react-bootstrap';
-import backArrow from '../images/back-arrow.png';
+import { Row, Col } from 'react-bootstrap';
+import { ArrowLeft } from 'phosphor-react';
+
 export default function CardHeader ({ title, backClickHandler }) {
   return (
     <>
       <Row className="align-items-center text-center position-relative py-2">
         <Col style={{ marginLeft: 25, marginRight: 25 }}>
           {backClickHandler && (
-            <Image
+            <ArrowLeft
+              size={24}
+              onClick={() => backClickHandler()}
+              style={{
+                position: 'absolute',
+                left: 10,
+                top: '0.75rem',
+                color: '#6C757D',
+                cursor: 'pointer'
+              }}
+            />
+          /*             <Image
               src={backArrow}
               style={{
                 width: 20,
@@ -17,7 +29,7 @@ export default function CardHeader ({ title, backClickHandler }) {
                 cursor: 'pointer'
               }}
               onClick={() => backClickHandler()}
-            />
+            /> */
           )}
           <h2>{title}</h2>
         </Col>

--- a/src/components/CardHeader.js
+++ b/src/components/CardHeader.js
@@ -1,11 +1,14 @@
 import { Row, Col } from 'react-bootstrap';
 import { ArrowLeft } from 'phosphor-react';
 
-export default function CardHeader ({ title, backClickHandler }) {
+export default function CardHeader ({ cardText, title, backClickHandler }) {
   return (
     <>
-      <Row className="align-items-center text-center position-relative py-2">
-        <Col style={{ marginLeft: 25, marginRight: 25 }}>
+      <Row
+        className="align-items-center text-center position-relative pt-2 no-gutters"
+        style={{ marginBottom: '2rem' }}
+      >
+        <Col>
           {backClickHandler && (
             <ArrowLeft
               size={24}
@@ -14,24 +17,13 @@ export default function CardHeader ({ title, backClickHandler }) {
                 position: 'absolute',
                 left: 10,
                 top: '0.75rem',
-                color: '#6C757D',
+                color: '#9CA3AF',
                 cursor: 'pointer'
               }}
             />
-          /*             <Image
-              src={backArrow}
-              style={{
-                width: 20,
-                position: 'absolute',
-                left: 10,
-                top: '1rem',
-                zIndex: 5,
-                cursor: 'pointer'
-              }}
-              onClick={() => backClickHandler()}
-            /> */
           )}
           <h2>{title}</h2>
+          <p className='text-center text-card'>{cardText}</p>
         </Col>
       </Row>
     </>

--- a/src/components/Divider.js
+++ b/src/components/Divider.js
@@ -1,0 +1,9 @@
+export default function Divider ({ text }) {
+  return (
+    <div className="d-flex flex-row align-items-center py-5">
+      <div className="d-flex flex-grow-1 border-top"></div>
+      <div className="px-3">{text}</div>
+      <div className="d-flex flex-grow-1 border-top"></div>
+    </div>
+  );
+}

--- a/src/components/Divider.js
+++ b/src/components/Divider.js
@@ -1,6 +1,6 @@
 export default function Divider ({ text }) {
   return (
-    <div className="d-flex flex-row align-items-center py-5">
+    <div className="d-flex flex-row align-items-center w-100 py-5">
       <div className="d-flex flex-grow-1 border-top"></div>
       <div className="px-3">{text}</div>
       <div className="d-flex flex-grow-1 border-top"></div>

--- a/src/pages/gift/accounts/ConnectExtension.js
+++ b/src/pages/gift/accounts/ConnectExtension.js
@@ -31,9 +31,9 @@ export default function ExtensionAccount({
   };
   return (
     <>
-      <Card.Body>
+      <Card.Body className='d-flex flex-column'>
         <CardHeader
-          title={title || 'Select Your Account'}
+          title={title || 'Select Account'}
           backClickHandler={prevStepHandler}
         />
         <div className="p-3">
@@ -50,12 +50,12 @@ export default function ExtensionAccount({
               />
             </Col>
           </Row>
-          <Row>
+        </div>
+        <Row>
             <Col className="pt-4 d-flex justify-content-center">
               <Button onClick={() => _setAccountHandler()}>Connect</Button>
             </Col>
           </Row>
-        </div>
       </Card.Body>
     </>
   );

--- a/src/pages/gift/accounts/ConnectSigner.js
+++ b/src/pages/gift/accounts/ConnectSigner.js
@@ -45,16 +45,11 @@ export default function SignerAccount({
   return (
     <>
       <Card.Body>
-        <CardHeader title='Scan QR Code' backClickHandler={() => prevStepHandler()} />
-        <Row className="justify-content-center align-items-center">
-          <Col className="d-flex flex-column justify-content-center align-items-center pt-4">
-            <p className="text-center">
-              <span className="d-block">
-                Scan your account QRCode from your signer app.
-              </span>
-            </p>
-          </Col>
-        </Row>
+        <CardHeader
+          title='Scan QR Code'
+          cardText='Scan your account QRCode from your Signer app.'
+          backClickHandler={() => prevStepHandler()}
+        />
         <Row className="justify-content-center align-items-center">
           {showReader ? (
             <Col className="d-flex justify-content-center">

--- a/src/pages/gift/claim/ClaimMain.js
+++ b/src/pages/gift/claim/ClaimMain.js
@@ -168,7 +168,7 @@ export default function ClaimMain() {
         <Row className="my-2 my-md-5 justify-content-center align-items-center">
           <Col className="my-md-5 d-flex justify-content-center align-items-center">
             <Card
-              style={{ width: 650, maxWidth: '100%', minHeight: 500 }}
+              style={{ width: 664, maxWidth: '100%', minHeight: 540 }}
               className="shadow">
               {currentStepComponent}
             </Card>

--- a/src/pages/gift/claim/Landing.js
+++ b/src/pages/gift/claim/Landing.js
@@ -9,31 +9,28 @@ import Divider from '../../../components/Divider';
 export default function Landing ({ setAccountSourceHandler }) {
   return (
     <>
-      <Card.Body>
+      <Card.Body className='d-flex flex-column'>
         <CardHeader
           title="Dot Account"
           cardText='Create a new Polkadot account to transfer your gift to.'
         />
-        <Row className="justify-content-center align-items-center">
-          <Col className="d-flex flex-column justify-content-center align-items-center pt-2">
+        <Col className="d-flex flex-column  flex-grow-1 justify-content-center align-items-center">
+          <Row className="d-flex flex-column justify-content-center align-items-center pt-2">
             <Button
               variant="outline-primary"
               onClick={() => setAccountSourceHandler('NEW')}>
               Create Polkadot Account
             </Button>
-          </Col>
-        </Row>
-        <Divider text='Or'/>
-        <Row className="align-items-center">
-          <div className="w-100" />
-          <Col className="d-flex flex-column justify-content-center align-items-center">
+          </Row>
+          <Divider text='Or'/>
+          <Row className="d-flex flex-column justify-content-center align-items-center">
             <LinkButton
               variant="link"
               onClick={() => setAccountSourceHandler('EXISTING')}>
               Connect Existing Account
             </LinkButton>
-          </Col>
-        </Row>
+          </Row>
+        </Col>
       </Card.Body>
       <Card.Footer>
         <span>

--- a/src/pages/gift/claim/Landing.js
+++ b/src/pages/gift/claim/Landing.js
@@ -2,19 +2,20 @@ import { useContext } from 'react';
 import { ClaimContext } from './ClaimMain';
 import { Card, Row, Col } from 'react-bootstrap';
 import Button from '../../../components/CustomButton';
+import LinkButton from '../../../components/LinkButton';
 import CardHeader from '../../../components/CardHeader';
-export default function Landing({ setAccountSourceHandler }) {
+import Divider from '../../../components/Divider';
+
+export default function Landing ({ setAccountSourceHandler }) {
   return (
     <>
       <Card.Body>
-        <CardHeader title="Dot Account" />
+        <CardHeader
+          title="Dot Account"
+          cardText='Create a new Polkadot account to transfer your gift to.'
+        />
         <Row className="justify-content-center align-items-center">
-          <Col className="d-flex flex-column justify-content-center align-items-center pt-4">
-            <p className="text-center">
-              <span className="d-block">
-                Create a new Polkadot account to transfer your gift to.
-              </span>
-            </p>
+          <Col className="d-flex flex-column justify-content-center align-items-center pt-2">
             <Button
               variant="outline-primary"
               onClick={() => setAccountSourceHandler('NEW')}>
@@ -22,19 +23,15 @@ export default function Landing({ setAccountSourceHandler }) {
             </Button>
           </Col>
         </Row>
-        <div className="d-flex flex-row align-items-center py-5">
-          <div className="d-flex flex-grow-1 border-top"></div>
-          <div className="px-3">Or</div>
-          <div className="d-flex flex-grow-1 border-top"></div>
-        </div>
+        <Divider text='Or'/>
         <Row className="align-items-center">
           <div className="w-100" />
           <Col className="d-flex flex-column justify-content-center align-items-center">
-            <Button
+            <LinkButton
               variant="link"
               onClick={() => setAccountSourceHandler('EXISTING')}>
               Connect Existing Account
-            </Button>
+            </LinkButton>
           </Col>
         </Row>
       </Card.Body>

--- a/src/pages/gift/claim/VerifySecret.js
+++ b/src/pages/gift/claim/VerifySecret.js
@@ -16,16 +16,13 @@ export default function VerifySecret({ claimGiftHandler }) {
   return (
     <>
       <Card.Body>
-        <CardHeader title={'Claim Your Gift'} backClickHandler={prevStep} />
+        <CardHeader
+          title={'Claim Your Gift'}
+          cardText='Every Polkadot account needs a minimum balance to be active on
+          the network. Enter the secret hash you have received to claim your gift and fund your account.'
+          backClickHandler={prevStep}
+        />
         <div>
-          <Row className="justify-content-center align-items-center">
-            <Col className="text-center">
-              <p>
-                Every Polkadot account needs a minimum balance to be active on
-                the network. Enter the secret hash you have received to claim your gift and fund your account.
-              </p>
-            </Col>
-          </Row>
           <Row className="pt-4 justify-content-center align-items-center">
             <Col>
               <Form autoComplete="off" className="w-100">

--- a/src/pages/gift/claim/VerifySecret.js
+++ b/src/pages/gift/claim/VerifySecret.js
@@ -15,35 +15,34 @@ export default function VerifySecret({ claimGiftHandler }) {
   };
   return (
     <>
-      <Card.Body>
+      <Card.Body className='d-flex flex-column'>
         <CardHeader
           title={'Claim Your Gift'}
           cardText='Every Polkadot account needs a minimum balance to be active on
           the network. Enter the secret hash you have received to claim your gift and fund your account.'
           backClickHandler={prevStep}
         />
-        <div>
-          <Row className="pt-4 justify-content-center align-items-center">
-            <Col>
-              <Form autoComplete="off" className="w-100">
-                <Form.Group controlId="formGroupWord1">
-                  <Form.Label>Secret Gift Hash</Form.Label>
-                  <Form.Control
-                    type="input"
-                    placeholder="0x4rt6..."
-                    onChange={(e) => setRedeemSecret(e.target.value)}
-                    value={redeemSecret}
-                  />
-                </Form.Group>
-              </Form>
-            </Col>
-          </Row>
-          <Row className=" pt-5 justify-content-center align-items-center">
-            <Col className="d-flex justify-content-center">
-              <Button onClick={() => redeemHandler()}>Claim Gift</Button>
-            </Col>
-          </Row>
-        </div>
+        <Row className="pt-4 justify-content-center align-items-center">
+          <Col>
+            <Form autoComplete="off" className="w-100">
+              <Form.Group controlId="formGroupWord1">
+                <Form.Label>Secret Gift Hash</Form.Label>
+                <Form.Control
+                  type="input"
+                  placeholder="0x4rt6..."
+                  onChange={(e) => setRedeemSecret(e.target.value)}
+                  value={redeemSecret}
+                />
+              </Form.Group>
+            </Form>
+          </Col>
+        </Row>
+        <div className='d-flex flex-grow-1' />
+        <Row className=" pt-5 justify-content-center align-items-center">
+          <Col className="d-flex justify-content-center">
+            <Button onClick={() => redeemHandler()}>Claim Gift</Button>
+          </Col>
+        </Row>
       </Card.Body>
     </>
   );

--- a/src/pages/gift/claim/existing-account/ConnectExistingAccount.js
+++ b/src/pages/gift/claim/existing-account/ConnectExistingAccount.js
@@ -12,44 +12,36 @@ const ConnectExistingAccount = ({
 }) => {
   return (
     <Card.Body className='d-flex flex-column'>
-      <CardHeader title="Connect Account" backClickHandler={prevStepHandler} />
-      <Col className="align-items-center">
-        <Col className="d-flex flex-column align-items-center pt-3">
-          <p className="text-center text-card">
-            <span className="d-block">
-              Connect an existing Polkadot account.
-            </span>
-          </p>
-        </Col>
+      <CardHeader
+        title="Connect Account"
+        cardText='Connect an existing Polkadot account.'
+        backClickHandler={prevStepHandler} />
+      <Col className="d-flex flex-column  flex-grow-1 justify-content-center align-items-center">
+        <Row>
+          <Col>
+            <CardButton
+              logo="extension"
+              onClick={() => setExistingAccountSourceHandler('EXTENSION')}>
+              Polkadot Extension
+            </CardButton>
+          </Col>
+          <Col>
+            <CardButton
+              logo="signer"
+              onClick={() => setExistingAccountSourceHandler('SIGNER')}>
+              Parity Signer
+            </CardButton>
+          </Col>
+        </Row>
+        <Divider text='Or' />
+        <Row className='justify-content-center pb-4'>
+          <LinkButton
+            className='tertiary-button'
+            onClick={() => setExistingAccountSourceHandler('ENTER')}>
+            Enter Address Manually
+          </LinkButton>
+        </Row>
       </Col>
-      <div className='flex-grow-1 align-items-center'>
-        <div>
-          <Row>
-            <Col>
-              <CardButton
-                logo="extension"
-                onClick={() => setExistingAccountSourceHandler('EXTENSION')}>
-                Polkadot Extension
-              </CardButton>
-            </Col>
-            <Col>
-              <CardButton
-                logo="signer"
-                onClick={() => setExistingAccountSourceHandler('SIGNER')}>
-                Parity Signer
-              </CardButton>
-            </Col>
-          </Row>
-          <Divider text='Or' />
-          <Row className='justify-content-center'>
-            <LinkButton
-              className='tertiary-button'
-              onClick={() => setExistingAccountSourceHandler('ENTER')}>
-              Enter Address Manually
-            </LinkButton>
-          </Row>
-        </div>
-      </div>
     </Card.Body>
   );
 };

--- a/src/pages/gift/claim/existing-account/ConnectExistingAccount.js
+++ b/src/pages/gift/claim/existing-account/ConnectExistingAccount.js
@@ -4,51 +4,52 @@ import { Card, Row, Col } from 'react-bootstrap';
 import LinkButton from '../../../../components/LinkButton';
 import CardButton from '../../../../components/CardButton';
 import CardHeader from '../../../../components/CardHeader';
+import Divider from '../../../../components/Divider';
 
 const ConnectExistingAccount = ({
   setExistingAccountSourceHandler,
   prevStepHandler,
 }) => {
   return (
-    <Card.Body>
+    <Card.Body className='d-flex flex-column'>
       <CardHeader title="Connect Account" backClickHandler={prevStepHandler} />
-      <Col className="justify-content-center align-items-center">
-        <Col className="d-flex flex-column justify-content-center align-items-center pt-4">
-          <p className="text-center">
+      <Col className="align-items-center">
+        <Col className="d-flex flex-column align-items-center pt-3">
+          <p className="text-center text-card">
             <span className="d-block">
               Connect an existing Polkadot account.
             </span>
           </p>
         </Col>
-        <Row className='pt-4'>
-          <Col>
-            <CardButton
-              logo="extension"
-              onClick={() => setExistingAccountSourceHandler('EXTENSION')}>
-              Polkadot Extension
-            </CardButton>
-          </Col>
-          <Col>
-            <CardButton
-              logo="signer"
-              onClick={() => setExistingAccountSourceHandler('SIGNER')}>
-              Parity Signer
-            </CardButton>
-          </Col>
-        </Row>
-        <div className="d-flex flex-row align-items-center py-5">
-          <div className="d-flex flex-grow-1 border-top"></div>
-          <div className="px-2">Or</div>
-          <div className="d-flex flex-grow-1 border-top"></div>
-        </div>
-        <Row className='justify-content-center'>
-          <LinkButton
-            className='tertiary-button'
-            onClick={() => setExistingAccountSourceHandler('ENTER')}>
-            Enter Address Manually
-          </LinkButton>
-        </Row>
       </Col>
+      <div className='flex-grow-1 align-items-center'>
+        <div>
+          <Row>
+            <Col>
+              <CardButton
+                logo="extension"
+                onClick={() => setExistingAccountSourceHandler('EXTENSION')}>
+                Polkadot Extension
+              </CardButton>
+            </Col>
+            <Col>
+              <CardButton
+                logo="signer"
+                onClick={() => setExistingAccountSourceHandler('SIGNER')}>
+                Parity Signer
+              </CardButton>
+            </Col>
+          </Row>
+          <Divider text='Or' />
+          <Row className='justify-content-center'>
+            <LinkButton
+              className='tertiary-button'
+              onClick={() => setExistingAccountSourceHandler('ENTER')}>
+              Enter Address Manually
+            </LinkButton>
+          </Row>
+        </div>
+      </div>
     </Card.Body>
   );
 };

--- a/src/pages/gift/claim/existing-account/EnterAccountAddress.js
+++ b/src/pages/gift/claim/existing-account/EnterAccountAddress.js
@@ -30,16 +30,10 @@ export default function EnterAccountAddress({
       <Card.Body>
         <CardHeader
           title={'Account Address'}
+          cardText='Enter your existing Polkadot account address below'
           backClickHandler={prevStepHandler}
         />
         <div>
-          <Row className="justify-content-center align-items-center">
-            <Col className="d-flex flex-column justify-content-center align-items-center">
-              <p className="text-center">
-                Enter your existing Polkadot account address below
-              </p>
-            </Col>
-          </Row>
           <Row
             style={{ height: 200 }}
             className="justify-content-center align-items-center">

--- a/src/pages/gift/claim/existing-account/EnterAccountAddress.js
+++ b/src/pages/gift/claim/existing-account/EnterAccountAddress.js
@@ -33,39 +33,38 @@ export default function EnterAccountAddress({
           cardText='Enter your existing Polkadot account address below'
           backClickHandler={prevStepHandler}
         />
-        <div>
-          <Row
-            style={{ height: 200 }}
-            className="justify-content-center align-items-center">
-            <Col>
-              <Form autoComplete="off" className="w-100">
-                <Form.Group controlId="formAccountAddressGroup">
-                  <Form.Label>Account Address</Form.Label>
-                  <Form.Control
-                    type="input"
-                    placeholder="12YS..."
-                    isInvalid={!!addressError}
-                    onChange={(e) => {
-                      setAddressError('');
-                      setAddress(e.target.value);
-                    }}
-                    value={address}
-                  />
-                  {addressError && (
-                    <Form.Text className="text-danger">
-                      {addressError}
-                    </Form.Text>
-                  )}
-                </Form.Group>
-              </Form>
-            </Col>
-          </Row>
-          <Row className="pt-5">
-            <Col className="d-flex justify-content-center">
-              <Button onClick={() => _setAddressHandler()}>Claim Gift</Button>
-            </Col>
-          </Row>
-        </div>
+        <Row
+          style={{ height: 200 }}
+          className="justify-content-center align-items-center">
+          <Col>
+            <Form autoComplete="off" className="w-100">
+              <Form.Group controlId="formAccountAddressGroup">
+                <Form.Label>Account Address</Form.Label>
+                <Form.Control
+                  type="input"
+                  placeholder="12YS..."
+                  isInvalid={!!addressError}
+                  onChange={(e) => {
+                    setAddressError('');
+                    setAddress(e.target.value);
+                  }}
+                  value={address}
+                />
+                {addressError && (
+                  <Form.Text className="text-danger">
+                    {addressError}
+                  </Form.Text>
+                )}
+              </Form.Group>
+            </Form>
+          </Col>
+        </Row>
+        <div className="flex-grow-1" />
+        <Row>
+          <Col className="d-flex justify-content-center">
+            <Button onClick={() => _setAddressHandler()}>Claim Gift</Button>
+          </Col>
+        </Row>
       </Card.Body>
     </>
   );

--- a/src/pages/gift/claim/new-account/PresentAccountPhrase.js
+++ b/src/pages/gift/claim/new-account/PresentAccountPhrase.js
@@ -22,34 +22,34 @@ export default function PresentAccountPhrase({
           somewhere safe. This seed phrase allows you to recover your
           account and funds.'
         />
-        <Row className="p-5 justify-content-center align-items-center">
-          {mnemonicWords.map((word, index) => (
-            <Col md={4} key={index}>
-              <div className=" d-flex flex-row border-bottom border-primary">
-                <div className="text-secondary"> {`${index + 1}.`}</div>
-                <div className="text-center m-auto">{`${word}`}</div>
-              </div>
+        <div>
+          <div
+            className='d-flex flex-row flex-wrap p-2 mb-4 mt-5 rounded'
+            style={{ background: '#F9FAFB' }}
+          >
+            {mnemonicWords.map((word, index) => (
+                <div className="text-center font-weight-bold mx-1" key={index}>{`${word}`}</div>
+            ))}
+          </div>
+          <Row className="flex-column justify-content-center align-items-center">
+            <Col>
+              <Form.Check
+                className='ml-2'
+                type="checkbox"
+                value={checked}
+                label={label}
+                isInvalid={!!checkedError}
+                onChange={(e) => {
+                  setCheckedError('');
+                  setChecked(e.target.checked);
+                }}
+              />
+              {checkedError && (
+                <Form.Text className="text-danger">{checkedError}</Form.Text>
+              )}
             </Col>
-          ))}
-        </Row>
-        <Row className="flex-column justify-content-center align-items-center">
-          <Col>
-            <Form.Check
-              className='ml-2'
-              type="checkbox"
-              value={checked}
-              label={label}
-              isInvalid={!!checkedError}
-              onChange={(e) => {
-                setCheckedError('');
-                setChecked(e.target.checked);
-              }}
-            />
-            {checkedError && (
-              <Form.Text className="text-danger">{checkedError}</Form.Text>
-            )}
-          </Col>
-        </Row>
+          </Row>
+        </div>
         <div className='d-flex flex-grow-1' />
         <div className="pt-5 d-flex justify-content-center">
           <Button

--- a/src/pages/gift/claim/new-account/PresentAccountPhrase.js
+++ b/src/pages/gift/claim/new-account/PresentAccountPhrase.js
@@ -14,60 +14,52 @@ export default function PresentAccountPhrase({
   const checkedErrorMessage = 'Please confirm you have saved your account';
   return (
     <>
-      <Card.Body>
+      <Card.Body className='d-flex flex-column'>
         <CardHeader
           title={'Account Seed Phrase'}
           backClickHandler={() => prevStepHandler()}
+          cardText='Write down the following words in order and store them
+          somewhere safe. This seed phrase allows you to recover your
+          account and funds.'
         />
-        <div className="p-4">
-          <Row className="justify-content-center align-items-center">
-            <Col className="d-flex flex-column justify-content-center align-items-center">
-              <p className="text-center">
-                <span className="d-block">
-                  Write down the following words in order and store them
-                  somewhere safe. This seed phrase allows you to recover your
-                  account and funds.
-                </span>
-              </p>
+        <Row className="p-5 justify-content-center align-items-center">
+          {mnemonicWords.map((word, index) => (
+            <Col md={4} key={index}>
+              <div className=" d-flex flex-row border-bottom border-primary">
+                <div className="text-secondary"> {`${index + 1}.`}</div>
+                <div className="text-center m-auto">{`${word}`}</div>
+              </div>
             </Col>
-          </Row>
-          <Row className="p-5 justify-content-center align-items-center">
-            {mnemonicWords.map((word, index) => (
-              <Col md={4} key={index}>
-                <div className=" d-flex flex-row border-bottom border-primary">
-                  <div className="text-secondary"> {`${index + 1}.`}</div>
-                  <div className="text-center m-auto">{`${word}`}</div>
-                </div>
-              </Col>
-            ))}
-          </Row>
-          <Row className="flex-column justify-content-center align-items-center">
-            <Col>
-              <Form.Check
-                type="checkbox"
-                value={checked}
-                label={label}
-                isInvalid={!!checkedError}
-                onChange={(e) => {
-                  setCheckedError('');
-                  setChecked(e.target.checked);
-                }}
-              />
-              {checkedError && (
-                <Form.Text className="text-danger">{checkedError}</Form.Text>
-              )}
-            </Col>
-            <Col className="pt-5 d-flex justify-content-center">
-              <Button
-                onClick={() =>
-                  checked
-                    ? nextStepHandler()
-                    : setCheckedError(checkedErrorMessage)
-                }>
-                Next
-              </Button>
-            </Col>
-          </Row>
+          ))}
+        </Row>
+        <Row className="flex-column justify-content-center align-items-center">
+          <Col>
+            <Form.Check
+              className='ml-2'
+              type="checkbox"
+              value={checked}
+              label={label}
+              isInvalid={!!checkedError}
+              onChange={(e) => {
+                setCheckedError('');
+                setChecked(e.target.checked);
+              }}
+            />
+            {checkedError && (
+              <Form.Text className="text-danger">{checkedError}</Form.Text>
+            )}
+          </Col>
+        </Row>
+        <div className='d-flex flex-grow-1' />
+        <div className="pt-5 d-flex justify-content-center">
+          <Button
+            onClick={() =>
+              checked
+                ? nextStepHandler()
+                : setCheckedError(checkedErrorMessage)
+            }>
+            Next
+          </Button>
         </div>
       </Card.Body>
     </>

--- a/src/pages/gift/claim/new-account/VerifyAccountPhrase.js
+++ b/src/pages/gift/claim/new-account/VerifyAccountPhrase.js
@@ -25,21 +25,15 @@ export default function VerifyAccountPhrase({
     return isValid;
   };
   return (
-    <Card.Body>
+    <Card.Body className='d-flex flex-column'>
       <CardHeader
         title={'Verify Phrase'}
+        cardText='Enter the following words from the seed phrase to complete the
+        setup process.'
         backClickHandler={() => prevStepHandler()}
       />
       <div>
-        <Row className="justify-content-center pt-3 align-items-center">
-          <Col>
-            <p className="text-center">
-              Enter the following words from the seed phrase to complete the
-              setup process.
-            </p>
-          </Col>
-        </Row>
-        <Row className="justify-content-center pt-3 flex-column align-items-center">
+        <Row className="pt-5 flex-column">
           <Col>
             <Form autoComplete="off" className="w-100">
               <Form.Group controlId="formGroupWord1">
@@ -79,15 +73,16 @@ export default function VerifyAccountPhrase({
               </Form.Group>
             </Form>
           </Col>
-          <Col className="d-flex pt-4 justify-content-center align-items-center">
+        </Row>
+      </div>
+      <div className='flex-grow-1'/>
+      <Col className="d-flex pt-4 justify-content-center align-items-center">
             <Button
               variant="outline-primary"
               onClick={() => validate() && nextStepHandler()}>
               Verify Phrase
             </Button>
           </Col>
-        </Row>
-      </div>
     </Card.Body>
   );
 }

--- a/src/pages/gift/generate/GenerateGift.js
+++ b/src/pages/gift/generate/GenerateGift.js
@@ -87,17 +87,11 @@ export default function GenerateGift({ account, generateGiftHandler }) {
   };
   return (
     <>
-      <Card.Body>
-        <CardHeader title={'Gift Dots'} backClickHandler={() => prevStep()} />
-
-        <Row className="justify-content-center flex-column align-items-center pt-4">
-          <Col>
-            <p className="text-center">
-              Send DOTs to your friends and familiy, and have them join the
-              Polkadot Network today.
-            </p>
-          </Col>
-          <Col className="d-flex justify-content-center align-items-center pt-4">
+      <Card.Body className='d-flex flex-column'>
+        <CardHeader title={'Gift Dots'} cardText='Send DOTs to your friends and familiy, and have them join the
+              Polkadot Network today.' backClickHandler={() => prevStep()} />
+        <Row className="justify-content-center flex-column align-items-center pt-2">
+          <Col className="d-flex justify-content-center align-items-center pt-5">
             <Form autoComplete="off" className="w-100">
               <Form.Group className="row" controlId="formGroupEmail">
                 <Col md="6">
@@ -178,12 +172,13 @@ export default function GenerateGift({ account, generateGiftHandler }) {
               </Form.Group>
             </Form>
           </Col>
-          <Col className="d-flex justify-content-center">
+        </Row>
+        <div className='d-flex flex-grow-1'/>
+        <div className="d-flex justify-content-center">
             <Button onClick={() => _generateGiftHandler()}>
               Generate Gift
             </Button>
-          </Col>
-        </Row>
+        </div>
       </Card.Body>
     </>
   );

--- a/src/pages/gift/generate/GenerateGift.js
+++ b/src/pages/gift/generate/GenerateGift.js
@@ -88,10 +88,14 @@ export default function GenerateGift({ account, generateGiftHandler }) {
   return (
     <>
       <Card.Body className='d-flex flex-column'>
-        <CardHeader title={'Gift Dots'} cardText='Send DOTs to your friends and familiy, and have them join the
-              Polkadot Network today.' backClickHandler={() => prevStep()} />
-        <Row className="justify-content-center flex-column align-items-center pt-2">
-          <Col className="d-flex justify-content-center align-items-center pt-5">
+        <CardHeader
+          title={'Gift Dots'}
+          cardText='Send DOTs to your friends and familiy, and have them join the
+            Polkadot Network today.'
+          backClickHandler={() => prevStep()}
+        />
+        <Row className="flex-column align-items-center">
+          <Col className="d-flex justify-content-center align-items-center pt-4">
             <Form autoComplete="off" className="w-100">
               <Form.Group className="row" controlId="formGroupEmail">
                 <Col md="6">

--- a/src/pages/gift/generate/GenerateMain.js
+++ b/src/pages/gift/generate/GenerateMain.js
@@ -278,7 +278,7 @@ export default function GenerateMain() {
         <Row className="my-2 my-md-5 justify-content-center align-items-center">
           <Col className="my-md-5 d-flex justify-content-center align-items-center">
             <Card
-              style={{ width: 600, maxWidth: '100%', minHeight: 500 }}
+              style={{ width: 664, maxWidth: '100%', minHeight: 540 }}
               className="shadow">
               {currentComponent}
             </Card>

--- a/src/pages/gift/generate/Landing.js
+++ b/src/pages/gift/generate/Landing.js
@@ -8,15 +8,13 @@ export default function Landing() {
   return (
     <>
       <Card.Body>
-        <CardHeader title={'Gift Some Dots'} />
+        <CardHeader
+          title={'Gift Some Dots'}
+          cardText='Send DOTs to your friends and familiy, and have them join the
+          Polkadot Network today.'
+        />
         <Row className="justify-content-center align-items-center">
           <Col className="d-flex flex-column justify-content-around align-items-center">
-            <div className="p-4">
-              <p className="text-center">
-                Send DOTs to your friends and familiy, and have them join the
-                Polkadot Network today.
-              </p>
-            </div>
             <div className="pt-5">
               <Button variant="outline-primary" onClick={() => nextStep()}>
                 Send a New Gift

--- a/src/pages/gift/generate/PresentGift.js
+++ b/src/pages/gift/generate/PresentGift.js
@@ -31,18 +31,14 @@ export default function PresentGift({ gift, removeGiftHandler }) {
   return (
     <>
       <Card.Body>
-        <CardHeader title={'Add Message'} />
-        <Row className="justify-content-center align-items-center">
-          <Col>
-            <p className="text-center">
-              Send DOTs to your friends and familiy, and have them join the
-              Polkadot Network today.
-            </p>
-          </Col>
-        </Row>
+        <CardHeader
+          title={'Add Message'}
+          cardText='Send DOTs to your friends and familiy, and have them join the
+          Polkadot Network today.'
+        />
         <Row className="justify-content-center align-items-center my-4 mx-2">
           <Col>
-            <Card className="printable">
+            <Card className="printable border">
               <Card.Body className='p-4'>
                 <p>
                   Hey!

--- a/src/polkadot.scss
+++ b/src/polkadot.scss
@@ -71,6 +71,7 @@ $card-border-radius: 20px;
   justify-content: center;
   padding: 1rem !important;
   font-size: 14px;
+  border-top-color: #d5dbe0 !important;
 }
 
 // Set booststrap custom theme

--- a/src/polkadot.scss
+++ b/src/polkadot.scss
@@ -58,6 +58,10 @@ $btn-border-radius-sm: 1.5rem;
 // Card
 $card-border-radius: 20px;
 
+.card {
+  border: none !important;
+}
+
 .card-body {
   padding: 2rem !important;
 }
@@ -80,6 +84,11 @@ $gray-600: #6c757d;
 $gray-900: #1e1e1e;
 
 // Fonts
+.text-card {
+  font-size: 1.125rem;
+  color: $gray-600;
+}
+
 .text-large {
   font-size: 1.25rem;
 }


### PR DESCRIPTION
Opening this as an optional PR.

Presents the seed phrase as a stylised string as opposed to the table format. So order is obvious without thinking about whether to read left-to-right or top-to-bottom. 
<img width="795" alt="Screenshot 2021-05-20 at 17 50 26" src="https://user-images.githubusercontent.com/7072141/119010108-02e82a00-b994-11eb-9f06-f0543f2877ad.png">
