### PR TITLE
change gift secret from hex to space formatted numbers

### DIFF
--- a/src/pages/gift/claim/VerifySecret.js
+++ b/src/pages/gift/claim/VerifySecret.js
@@ -4,20 +4,22 @@ import { ClaimContext } from './ClaimMain';
 import CardHeader from '../../../components/CardHeader';
 import { useSubstrate } from '../../../substrate-lib';
 import { Formik } from 'formik';
+import { stringHelpers } from '../../../utils';
 
 export default function VerifySecret ({ claimGiftHandler }) {
   const { prevStep } = useContext(ClaimContext);
   const redeemHandler = (redeemSecret) => {
     // ToDO: add better input validation to verify redeemSecret is not empty,
     // and is indeed a valid mnemonic phrase
-    redeemSecret = redeemSecret.trim();
+    redeemSecret = stringHelpers.removeSpaces(redeemSecret);
+    console.log(redeemSecret);
     if (redeemSecret) {
       claimGiftHandler(redeemSecret);
     }
   };
   const { giftTheme } = useSubstrate();
   const validate = ({ redeemSecret }) => {
-    redeemSecret = redeemSecret.trim();
+    redeemSecret = stringHelpers.removeSpaces(redeemSecret);
     const errors = {};
     if (!redeemSecret || !/^[\w ]+$/i.test(redeemSecret)) {
       errors.redeemSecret = 'Please enter a valid gift secret.';

--- a/src/pages/gift/claim/VerifySecret.js
+++ b/src/pages/gift/claim/VerifySecret.js
@@ -12,7 +12,6 @@ export default function VerifySecret ({ claimGiftHandler }) {
     // ToDO: add better input validation to verify redeemSecret is not empty,
     // and is indeed a valid mnemonic phrase
     redeemSecret = stringHelpers.removeSpaces(redeemSecret);
-    console.log(redeemSecret);
     if (redeemSecret) {
       claimGiftHandler(redeemSecret);
     }

--- a/src/pages/gift/generate/PresentGift.js
+++ b/src/pages/gift/generate/PresentGift.js
@@ -2,6 +2,7 @@ import { Row, Col, Card } from 'react-bootstrap';
 import CardHeader from '../../../components/CardHeader';
 import { useSubstrate, utils } from '../../../substrate-lib';
 import config from '../../../config';
+import { stringHelpers } from '../../../utils';
 
 export default function PresentGift ({ gift, removeGiftHandler }) {
   const { email, amount, secret } = gift;
@@ -9,13 +10,14 @@ export default function PresentGift ({ gift, removeGiftHandler }) {
   const amountStr = amount && utils.formatBalance(amount, chainInfo?.token);
   const mailSubject = `Someone has sent you ${giftTheme?.content}`;
   const claimUrl = config.CLAIM_URL;
+  const formattedSecret = stringHelpers.formatGiftSecret(secret);
   const mailBody = `
   Hey! \n 
   I'm sending you ${amountStr} as a gift! You can go to \n
   ${claimUrl} \n
   and type in the following secret message to claim your ${giftTheme?.content}. 
   \n \n 
-  ${secret} 
+  ${formattedSecret} 
   \n \n 
   The website will walk you through to create your own secure
   ${giftTheme.network} account. \n 
@@ -70,7 +72,7 @@ export default function PresentGift ({ gift, removeGiftHandler }) {
                       marginBottom: '20px',
                       borderRadius: '5px'
                     }}>
-                    {secret}
+                    {formattedSecret}
                   </strong>
                   The website will walk you through to create your own secure{' '}
                   {`${giftTheme.network}`} account.

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,5 +14,8 @@ export const stringHelpers = {
       formatted.push(giftSecret.slice(i, i + 4));
     }
     return formatted.join(' ');
+  },
+  removeSpaces: (giftSecret) => {
+    return giftSecret.replace(/[\s]*/g, '');
   }
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,5 +7,12 @@ export const stringHelpers = {
       )}`;
     }
     return truncated;
+  },
+  formatGiftSecret: (giftSecret) => {
+    const formatted = [];
+    for (let i = 0; i < giftSecret.length; i += 4) {
+      formatted.push(giftSecret.slice(i, i + 4));
+    }
+    return formatted.join(' ');
   }
 };


### PR DESCRIPTION
The current gift secrets are random hashes which are hard to enter manually.
This changes will change the secret to 16 digit numbers and the app will display them as space separated 4 digits parts which make it similar to credit card numbers that most people are familiar with and are easy to read.