### PR TITLE
change support link

### DIFF
--- a/src/pages/gift/about/FAQ.js
+++ b/src/pages/gift/about/FAQ.js
@@ -32,8 +32,8 @@ export default function FAQ ({ giftTheme }) {
     'Try reaching out to your recipient personally. If your recipient still does not claim the gift, there is an option to revoke it and return the gift amount to your account.';
   const a6 = (
     <p className="pb-3">
-      Please contact&nbsp;
-      <a href={'mailto:support@polkadot.network'}>{'support@polkadot.network'}</a>.
+      Please visit our&nbsp;
+      <a href="https://support.polkadot.network/" rel="noreferrer" target="_blank">support page</a>.
     </p>
   );
 

--- a/src/pages/gift/footer/KusamaFooter.js
+++ b/src/pages/gift/footer/KusamaFooter.js
@@ -19,9 +19,7 @@ export default function Footer ({ className, selectedAccount }) {
       <div className="footer-grow flex-grow-1" />
       <div>
         <strong>Questions?</strong>&nbsp;
-        <a href="mailto:support@polkadot.network?subject=Gifts">
-          support@polkadot.network
-        </a>
+        <a href="https://support.polkadot.network/" rel="noreferrer" target="_blank">Visit our support page.</a>
       </div>
     </footer>
   );

--- a/src/pages/gift/footer/PolkadotFooter.js
+++ b/src/pages/gift/footer/PolkadotFooter.js
@@ -19,9 +19,7 @@ export default function Footer ({ className, selectedAccount }) {
       <div className="footer-grow flex-grow-1" />
       <div>
         <strong>Questions?</strong>&nbsp;
-        <a href="mailto:support@polkadot.network?subject=Gifts">
-          support@polkadot.network
-        </a>
+        <a href="https://support.polkadot.network/" rel="noreferrer" target="_blank">Visit our support page.</a>
       </div>
     </footer>
   );


### PR DESCRIPTION
Per a request from support,  references to the support email is changed to the support page that they track from now on. 