### PR TITLE
Add security headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'"
+    X-XSS-Protection = "1; mode=block"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "same-origin"
+    X-Frame-Options = "SAMEORIGIN"
+    Feature-Policy = "microphone 'none'; geolocation 'none'"
+    


### PR DESCRIPTION
To prevent including pages into iframes and attackers injecting javascript code please add the following headers:

Content-Security-Policy - prevents attackers from loading code from URLs they control
X-XSS-Protection - prevent cross site scripting attacks thru URL parameters
X-Content-Type-Options - prevent serving unexpected MIME types
Referrer-Policy - prevents the page from leaking referrer headers to other pages
X-Frame-Options - prevents embedding in iframes (for older browsers)
Feature-Policy - defines what APIs the page is using, prevent mic and geo to secure users from tracking services

This PR needs to be published to all deployed instances on netlify.

Addressing issue: https://github.com/w3f-webops/gift-kusama/issues/3